### PR TITLE
link files within a Bazel sandbox to the corresponding project file

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -18,6 +18,10 @@
 * [ ] Add: Handle fqn with relative path suffix to allow resource refs using query suffix to fqn
       class name. Something like `fqn://...?resourcePath#LineInfo`.
 
+### 1.1.9 - Dev Build
+
+* Change: link files within a Bazel sandbox to the corresponding project file
+
 ### 1.1.8 - Bug Fix Release
 
 * Fix: migrate to gradle build

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 def javaVersion = "11"
-def pluginVersion = "1.1.8"
+def pluginVersion = "1.1.9"
 def pluginSinceBuild = "203"
 def pluginUntilBuild = ""
 

--- a/src/com/vladsch/plugins/consolefilecaddy/ConsoleFileCaddyFilter.java
+++ b/src/com/vladsch/plugins/consolefilecaddy/ConsoleFileCaddyFilter.java
@@ -68,8 +68,9 @@ public class ConsoleFileCaddyFilter implements Filter, DumbAware {
     final protected static String FILE_PROTOCOL_PREFIX = "file:///";
     public static final String FQN_PREFIX = "fqn://";
     public static final String DIFF_PREFIX = "diff://";
+    private static final String BAZEL_SANDBOX_FILE_PART = ".runfiles/__main__/";
 
-    final protected static String ANCHOR_SUFFIX = "(?:(?:[#:(\\[]\\s?L?(\\d+)[^/\\\\\\dL]?(?:L?(\\d+)?[)\\]]?))?)(?:$|[ \\t>)]|:])";
+    final protected static String ANCHOR_SUFFIX = "(?:(?:[#:(\\[]\\s?L?(\\d+)[^/\\\\\\dL]?(?:L?(\\d+)?[)\\]]?))?)(?:$|[ \\t>)]|:)";
     final protected static String ANCHOR_SUFFIX_DIFF_1 = "(?:(?:[#:(\\[]\\s?L?(\\d+)[^/\\\\\\dL]?(?:L?(\\d+)?[)\\]]?))?)";
     final protected static String ANCHOR_SUFFIX_DIFF_2 = "(?:(?:[#:(\\[]\\s?L?(\\d+)[^/\\\\\\dL]?(?:L?(\\d+)?[)\\]]?))?)(?:[ \\t]*?\\&)";
     final protected static String CLASS_FQN = "(?:fqn://[^ \\t]+?)";
@@ -169,6 +170,9 @@ public class ConsoleFileCaddyFilter implements Filter, DumbAware {
                 if (filePath.startsWith(FILE_PROTOCOL_PREFIX)) fixedFilePath = filePath.substring(FILE_PROTOCOL_PREFIX.length() - leadSlash);
                 else if (filePath.startsWith(FILE_PROTOCOL_PREFIX.substring(0, FILE_PROTOCOL_PREFIX.length() - 1))) fixedFilePath = filePath.substring(FILE_PROTOCOL_PREFIX.length() - 1 - leadSlash);
                 else if (filePath.startsWith(FILE_PROTOCOL_PREFIX.substring(0, FILE_PROTOCOL_PREFIX.length() - 2))) fixedFilePath = filePath.substring(FILE_PROTOCOL_PREFIX.length() - 2 - leadSlash);
+                if (myProject != null && fixedFilePath.contains(BAZEL_SANDBOX_FILE_PART)) {
+                    fixedFilePath = myProject.getBasePath() + "/" + fixedFilePath.split(BAZEL_SANDBOX_FILE_PART)[1];
+                }
                 LOG.debug("Fixed file path: " + fixedFilePath);
 
                 File file = new File(fixedFilePath);


### PR DESCRIPTION
Very useful plugin! I extended it slightly for my purposes to link files within a Bazel sandbox to the corresponding project file. For example, in the shell output

    [ERROR] /home/user/.cache/bazel/_bazel_user/a84d3c6d5cc734a2e043d462a99e06c0/sandbox/linux-sandbox/452/execroot/__main__/bazel-out/k8-fastbuild/bin/project/api/application/project-api-checkstyle.runfiles/__main__/project/api/application/src/main/java/com/company/project/api/ApiMain.java:34:24: Variable 'configProvider' should be declared final. [FinalLocalVariable]

the plugin would link to the file `${PROJECT_DIR}/project/api/application/src/main/java/com/company/project/api/ApiMain.java` if a project is active (and the file is found).

Not sure if this is of general interest, feel free to ignore.

I did notice an issue with the regex that you may want to double-check in any case though: For the above example output line, the regex would match `/home/user/.cache/.../ApiMain.java:34` in group 2, `24` in group 3 and nothing in group 4.
Removing the final `]` from ANCHOR_SUFFIX gave me the desired behaviour (`/home/user/.cache/.../ApiMain.java` in group 2, `34` in 3, `24` in 4). Since that square bracket does not close a character range group, I don't think it is required.